### PR TITLE
Create new shift

### DIFF
--- a/server/api/schedule/router.ts
+++ b/server/api/schedule/router.ts
@@ -4,6 +4,7 @@ import { createTRPCRouter, publicProcedure, restrictedProcedure } from "../trpc"
 import { getUnfulfilledShifts } from "../../utils/getUnfulfilledShifts"
 import { Role } from "../../../prisma/role"
 import { generateSchedule } from "./generate-functions"
+import { prisma } from "../../db"
 
 export const scheduleRouter = createTRPCRouter({
   getUnfulfilledShifts: publicProcedure
@@ -25,5 +26,74 @@ export const scheduleRouter = createTRPCRouter({
             reject(error)
           })
       })
-    })
+    }),
+
+    getShiftTypes: publicProcedure
+    .query(() => {
+        return prisma.shift_Type.findMany({
+            select: {
+                name: true
+            }
+        })
+    }
+    ),
+    // return true if  shift by date and starttime 
+    checkShift: publicProcedure
+    .input(z.object({
+        date: z.date(),
+        startTime: z.string()
+    }))
+    .query(async ({ input }) => {
+        const start = 
+        new Date(input.date.getFullYear(), input.date.getMonth(), input.date.getDate(), parseInt(input.startTime.split(':')[0]), parseInt(input.startTime.split(':')[1]))
+        const shift = await prisma.shift.findFirst({
+            where: {
+                start: start
+            }
+        })
+        if (shift) {
+            return true
+        } else {
+            return false
+        }
+    }),
+
+   
+    createShift : publicProcedure
+    .input(
+      z.object({
+        start: z.date(),
+        end: z.date(),
+        staff_required: z.array(
+          z.object({
+            shift_type: z.string(),
+            amount: z.number(),
+          })
+        ),
+      })
+    )
+    .mutation(async ({ input }) => {
+      const shift = await prisma.shift.create({
+        data: {
+          start: input.start,
+          end: input.end,
+          staff_required: {
+            create: input.staff_required.map(({ shift_type, amount }) => ({
+              amount,
+              shift_type: {
+                connect: {
+                  name: shift_type,
+                },
+              },
+            })),
+          },
+        },
+      });
+      return shift;
+      }),
+
+      // get all shifts
+      getAllShifts : publicProcedure
+      .query(()=>prisma.shift.findMany()),
 })
+

--- a/server/api/schedule/router.ts
+++ b/server/api/schedule/router.ts
@@ -38,21 +38,20 @@ export const scheduleRouter = createTRPCRouter({
     }
     ),
     // return true if  shift by date and starttime 
-    checkShift: publicProcedure
+    checkShiftExistsByDate: publicProcedure
     .input(z.object({
-        date: z.date(),
-        startTime: z.string()
+      start: z.date(),
+      end: z.date(),
     }))
     .query(async ({ input }) => {
-        const start = 
-        new Date(input.date.getFullYear(), input.date.getMonth(), input.date.getDate(), parseInt(input.startTime.split(':')[0]), parseInt(input.startTime.split(':')[1]))
         const shift = await prisma.shift.findFirst({
             where: {
-                start: start
+                start: input.start,
+                end: input.end,
             }
         })
         if (shift) {
-            return true
+          return true
         } else {
             return false
         }
@@ -95,5 +94,7 @@ export const scheduleRouter = createTRPCRouter({
       // get all shifts
       getAllShifts : publicProcedure
       .query(()=>prisma.shift.findMany()),
+
+      
 })
 

--- a/server/api/shift/database-actions.ts
+++ b/server/api/shift/database-actions.ts
@@ -23,4 +23,5 @@ export const getShifts = async (fromDate?: Date, toDate?: Date) => {
       }
     }
   })
+
 }

--- a/src/pages/addShift.tsx
+++ b/src/pages/addShift.tsx
@@ -77,11 +77,9 @@ export default function AddShiftPage() {
     e.preventDefault();
 
     if (!selectedShift) {
-      console.error("Please select a shift");
       return;
     }
     if (!date) {
-      console.error("Please select a date");
       return;
     }
 
@@ -110,9 +108,6 @@ export default function AddShiftPage() {
       end.setHours(endHour, endMinute, 0, 0);
     }
 
-    // TODO
-    // If shift already exists with same start and end time return error
-
     try {
       createNewShift.mutate({
         start,
@@ -126,7 +121,6 @@ export default function AddShiftPage() {
       router.push("/");
 
     } catch (error) {
-      // show error use ToastService
       ToastService.error('Er is iets verkeerd gegaan!');
     }
   };

--- a/src/pages/addShift.tsx
+++ b/src/pages/addShift.tsx
@@ -1,0 +1,242 @@
+import React, { useState } from "react";
+import { useRouter } from "next/router";
+import { Button, TextField } from "../components";
+import { api } from "../utils/api";
+
+interface ShiftTypeStaffing {
+  [shiftTypeName: string]: number;
+}
+
+enum ShiftChoice {
+  MORNING = "morning",
+  AFTERNOON = "afternoon",
+  CUSTOM = "custom",
+}
+
+const shiftChoiceDetails = {
+  [ShiftChoice.MORNING]: {
+    label: "Ochtend (11:45 - 15:00)",
+    startHour: 9,
+    endHour: 14,
+  },
+  [ShiftChoice.AFTERNOON]: {
+    label: "Middag (14:00 - 17:15)",
+    startHour: 14,
+    endHour: 17,
+  },
+};
+
+export default function AddShiftPage() {
+  const [date, setDate] = useState("");
+  const [shiftTypeStaffing, setShiftTypeStaffing] = useState<ShiftTypeStaffing>({});
+  const [selectedShift, setSelectedShift] = useState<ShiftChoice | null>(null);
+  const [customStartTime, setCustomStartTime] = useState("");
+  const [customEndTime, setCustomEndTime] = useState("");
+  const router = useRouter();
+
+  const getAllShifts = api.schedule.getAllShifts.useQuery();
+  const getAllShiftTypeNames = api.schedule.getShiftTypes.useQuery();
+  const shiftTypeNames = getAllShiftTypeNames.data?.map((shiftType) => shiftType.name) || [];
+  const response = api.schedule.createShift.useMutation();
+
+  const handleShiftTypeStaffingChange = (shiftTypeName: string, value: string) => {
+    setShiftTypeStaffing((prevState: ShiftTypeStaffing) => ({
+      ...prevState,
+      [shiftTypeName]: parseInt(value, 10) || 0,
+    }));
+  };
+
+  const handleStaffingIncrement = (shiftTypeName: string) => {
+    setShiftTypeStaffing((prevState: ShiftTypeStaffing) => ({
+      ...prevState,
+      [shiftTypeName]: (prevState[shiftTypeName] || 0) + 1,
+    }));
+  };
+
+  const handleStaffingDecrement = (shiftTypeName: string) => {
+    setShiftTypeStaffing((prevState: ShiftTypeStaffing) => ({
+      ...prevState,
+      [shiftTypeName]: Math.max((prevState[shiftTypeName] || 0) - 1, 0),
+    }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!selectedShift) {
+      console.error("Please select a shift");
+      return;
+    }
+    if (!date) {
+      console.error("Please select a date");
+      return;
+    }
+
+    let start, end;
+    if (selectedShift === ShiftChoice.CUSTOM) {
+      if (!customStartTime || !customEndTime) {
+        console.error("Graag vul een geldige tijdstip in!");
+        return;
+      }
+      start = new Date(`${date}T${customStartTime}`);
+      end = new Date(`${date}T${customEndTime}`);
+    } else {
+      const { startHour, endHour } = shiftChoiceDetails[selectedShift];
+      start = new Date(date);
+      start.setHours(startHour, 0, 0, 0);
+      end = new Date(date);
+      end.setHours(endHour, 0, 0, 0);
+    }
+
+    try {
+      response.mutate({
+        start,
+        end,
+        staff_required: Object.entries(shiftTypeStaffing).map(([shiftTypeName, amount]) => ({
+          shift_type: shiftTypeName,
+          amount,
+        })),
+      });
+      router.push("/");
+    } catch (error) {
+      console.error("Error:", error);
+    }
+  };
+
+  return (
+    <div className="container mx-auto max-w-[500px] m-auto">
+      <h2 className="text-2xl font-bold mb-4">Shift toevoegen</h2>
+      <form onSubmit={handleSubmit} >
+        <div className="mb-4">
+          <h2 className="font-bold">Datum:</h2>
+          <TextField type="date" id="date" value={date} onChange={(value) => setDate(value)} />
+        </div>
+
+        <div className="mb-4 mt-10">
+          <h2 className="font-bold">Selecteer Tijdstip:</h2>
+          <div>
+            {Object.entries(shiftChoiceDetails).map(([shiftChoice, details]) => (
+              <div key={shiftChoice}>
+                <input
+                  type="radio"
+                  id={shiftChoice}
+                  name="shift"
+                  value={shiftChoice}
+                  checked={selectedShift === shiftChoice}
+                  onChange={() => setSelectedShift(shiftChoice as ShiftChoice)}
+                />
+                <label htmlFor={shiftChoice}>{details.label}</label>
+              </div>
+            ))}
+            <div>
+              <input
+                type="radio"
+                id={ShiftChoice.CUSTOM}
+                name="shift"
+                value={ShiftChoice.CUSTOM}
+                checked={selectedShift === ShiftChoice.CUSTOM}
+                onChange={() => setSelectedShift(ShiftChoice.CUSTOM)}
+              />
+              <label htmlFor={ShiftChoice.CUSTOM}>Aangepast</label>
+            </div>
+          </div>
+        </div>
+
+        {selectedShift && selectedShift !== ShiftChoice.CUSTOM && (
+          <div className="mb-4 mt-10">
+            <h2 className="font-bold">Select the staffing per shift type:</h2>
+            {shiftTypeNames.map((shiftTypeName) => (
+              <div key={shiftTypeName} className="flex items-center mb-2">
+                <label htmlFor={shiftTypeName} className="mr-2">
+                  {shiftTypeName}
+                </label>
+                <div className="flex items-center">
+                  <button
+                    type="button"
+                    onClick={() => handleStaffingDecrement(shiftTypeName)}
+                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 mr-2"
+                  >
+                    -
+                  </button>
+                  <TextField
+                    type="number"
+                    id={shiftTypeName}
+                    value={String(shiftTypeStaffing[shiftTypeName]) || ""}
+                    onChange={(value) => handleShiftTypeStaffingChange(shiftTypeName, value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleStaffingIncrement(shiftTypeName)}
+                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 ml-2"
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {selectedShift === ShiftChoice.CUSTOM && (
+          <div className="mb-4 mt-10">
+            <h2 className="font-bold">Voeg aangepaste shift tijdstip:</h2>
+            <div className="flex items-center mb-2">
+              <label htmlFor="custom-start-time" className="mr-2">
+                Start Time:
+              </label>
+              <TextField
+                type="time"
+                id="custom-start-time"
+                value={customStartTime}
+                onChange={(value) => setCustomStartTime(value)}
+              />
+            </div>
+            <div className="flex items-center">
+              <label htmlFor="custom-end-time" className="mr-2">
+                End Time:
+              </label>
+              <TextField
+                type="time"
+                id="custom-end-time"
+                value={customEndTime}
+                onChange={(value) => setCustomEndTime(value)}
+              />
+            </div>
+            <h2 className="font-bold mt-10">Benodigde personeel per locatie:</h2>
+            {shiftTypeNames.map((shiftTypeName) => (
+              <div key={shiftTypeName} className="flex items-center mb-2">
+                <label htmlFor={shiftTypeName} className="mr-2">
+                  {shiftTypeName}
+                </label>
+                <div className="flex items-center">
+                  <button
+                    type="button"
+                    onClick={() => handleStaffingDecrement(shiftTypeName)}
+                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 mr-2"
+                  >
+                    -
+                  </button>
+                  <TextField
+                    type="number"
+                    id={shiftTypeName}
+                    value={String(shiftTypeStaffing[shiftTypeName]) || ""}
+                    onChange={(value) => handleShiftTypeStaffingChange(shiftTypeName, value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => handleStaffingIncrement(shiftTypeName)}
+                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 ml-2"
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <Button type="submit">Add Shift</Button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/addShift.tsx
+++ b/src/pages/addShift.tsx
@@ -1,29 +1,43 @@
 import React, { useState } from "react";
 import { useRouter } from "next/router";
-import { Button, TextField } from "../components";
+import { Button, TextField, ToastService } from "../components";
 import { api } from "../utils/api";
+import { boolean } from "zod";
 
 interface ShiftTypeStaffing {
   [shiftTypeName: string]: number;
 }
 
 enum ShiftChoice {
-  MORNING = "morning",
+  MORNING = "ochtend",
   AFTERNOON = "afternoon",
+  AFTERNOON_EVENING = "middag-avond",
   CUSTOM = "custom",
+  
 }
 
 const shiftChoiceDetails = {
   [ShiftChoice.MORNING]: {
     label: "Ochtend (11:45 - 15:00)",
-    startHour: 9,
-    endHour: 14,
+    startHour: 11,
+    startMinute: 45,
+    endHour: 15,
+    endMinute: 0,
   },
   [ShiftChoice.AFTERNOON]: {
     label: "Middag (14:00 - 17:15)",
     startHour: 14,
+    startMinute: 0,
     endHour: 17,
+    endMinute: 15,
   },
+  [ShiftChoice.AFTERNOON_EVENING]: {
+    label: "Opening (11:45 - 17:15)",
+    startHour: 11,
+    startMinute: 45,
+    endHour: 17,
+    endMinute: 15,
+    }
 };
 
 export default function AddShiftPage() {
@@ -32,13 +46,11 @@ export default function AddShiftPage() {
   const [selectedShift, setSelectedShift] = useState<ShiftChoice | null>(null);
   const [customStartTime, setCustomStartTime] = useState("");
   const [customEndTime, setCustomEndTime] = useState("");
-  const [error, setError] = useState("");
   const router = useRouter();
 
-  const getAllShifts = api.schedule.getAllShifts.useQuery();
   const getAllShiftTypeNames = api.schedule.getShiftTypes.useQuery();
   const shiftTypeNames = getAllShiftTypeNames.data?.map((shiftType) => shiftType.name) || [];
-  const response = api.schedule.createShift.useMutation();
+  const createNewShift = api.schedule.createShift.useMutation();
 
   const handleShiftTypeStaffingChange = (shiftTypeName: string, value: string) => {
     setShiftTypeStaffing((prevState: ShiftTypeStaffing) => ({
@@ -65,38 +77,44 @@ export default function AddShiftPage() {
     e.preventDefault();
 
     if (!selectedShift) {
-      setError("Selecteer een shift");
+      console.error("Please select a shift");
       return;
     }
     if (!date) {
-      setError("Selecteer een datum");
+      console.error("Please select a date");
       return;
     }
 
-    let start: Date, end: Date;
+    let start;
+    let end;
+
     if (selectedShift === ShiftChoice.CUSTOM) {
       if (!customStartTime || !customEndTime) {
-        setError("Vul een geldig tijdstip in");
         return;
       }
-      start = new Date(`${date}T${customStartTime}`);
-      end = new Date(`${date}T${customEndTime}`);
-    } else {
-      const { startHour, endHour } = shiftChoiceDetails[selectedShift];
+
       start = new Date(date);
-      start.setHours(startHour, 0, 0, 0);
+      const [startHour, startMinute] = customStartTime.split(":");
+      start.setHours(parseInt(startHour, 10), parseInt(startMinute, 10), 0, 0);
+
       end = new Date(date);
-      end.setHours(endHour, 0, 0, 0);
+      const [endHour, endMinute] = customEndTime.split(":");
+      end.setHours(parseInt(endHour, 10), parseInt(endMinute, 10), 0, 0);
+    } else {
+      const { startHour, startMinute, endHour, endMinute } = shiftChoiceDetails[selectedShift];
+
+      start = new Date(date);
+      start.setHours(startHour, startMinute, 0, 0);
+
+      end = new Date(date);
+      end.setHours(endHour, endMinute, 0, 0);
     }
 
-    const existingShift = getAllShifts.data?.find((shift) => shift.start === start && shift.end === end);
-    if (existingShift) {
-      setError("Er bestaat al een shift met dezelfde start- en einddatum");
-      return;
-    }
+    // TODO
+    // If shift already exists with same start and end time return error
 
     try {
-      response.mutate({
+      createNewShift.mutate({
         start,
         end,
         staff_required: Object.entries(shiftTypeStaffing).map(([shiftTypeName, amount]) => ({
@@ -104,59 +122,87 @@ export default function AddShiftPage() {
           amount,
         })),
       });
+      ToastService.success('Shift is toegevoeg');
       router.push("/");
+
     } catch (error) {
-      console.error("Error:", error);
+      // show error use ToastService
+      ToastService.error('Er is iets verkeerd gegaan!');
     }
   };
 
   return (
     <div className="container mx-auto max-w-[500px] m-auto">
-      <h2 className="text-2xl font-bold mb-4">Shift toevoegen</h2>
+      <h1 className="text-2xl font-bold mb-4 text-center m-10">SHIFT TOEVOEGEN</h1>
       <form onSubmit={handleSubmit}>
-        <div className="mb-4">
-          <h2 className="font-bold">Datum:</h2>
+        <div className="mb-4 m-5">
+          <h2 className="font-bold">Selecteer de datum:</h2>
           <TextField type="date" id="date" value={date} onChange={(value) => setDate(value)} />
         </div>
 
-        <div className="mb-4 mt-10">
-          <h2 className="font-bold">Selecteer Tijdstip:</h2>
+        <div className="mb-4 m-5 mt-10">
+          <h2 className="font-bold">Selecteer de shift:</h2>
           <div>
-            {Object.entries(shiftChoiceDetails).map(([shiftChoice, details]) => (
-              <div key={shiftChoice}>
-                <input
-                  type="radio"
-                  id={shiftChoice}
-                  name="shift"
-                  value={shiftChoice}
-                  checked={selectedShift === shiftChoice}
-                  onChange={() => setSelectedShift(shiftChoice as ShiftChoice)}
-                />
-                <label htmlFor={shiftChoice}>{details.label}</label>
-              </div>
-            ))}
-            <div>
-              <input
-                type="radio"
-                id={ShiftChoice.CUSTOM}
-                name="shift"
-                value={ShiftChoice.CUSTOM}
-                checked={selectedShift === ShiftChoice.CUSTOM}
-                onChange={() => setSelectedShift(ShiftChoice.CUSTOM)}
-              />
-              <label htmlFor={ShiftChoice.CUSTOM}>Aangepast</label>
-            </div>
+            <input
+              type="radio"
+              id="morning"
+              name="shift"
+              value={ShiftChoice.MORNING}
+              checked={selectedShift === ShiftChoice.MORNING}
+              onChange={() => setSelectedShift(ShiftChoice.MORNING)}
+            />
+            <label htmlFor="morning">{shiftChoiceDetails[ShiftChoice.MORNING].label}</label>
           </div>
+          <div>
+            <input
+              type="radio"
+              id="afternoon"
+              name="shift"
+              value={ShiftChoice.AFTERNOON}
+              checked={selectedShift === ShiftChoice.AFTERNOON}
+              onChange={() => setSelectedShift(ShiftChoice.AFTERNOON)}
+            />
+            <label htmlFor="afternoon">{shiftChoiceDetails[ShiftChoice.AFTERNOON].label}</label>
+          </div>
+          <div>
+            <input
+              type="radio"
+              id="afternoon_evening"
+              name="shift"
+              value={ShiftChoice.AFTERNOON_EVENING}
+              checked={selectedShift === ShiftChoice.AFTERNOON_EVENING}
+              onChange={() => setSelectedShift(ShiftChoice.AFTERNOON_EVENING)}
+            />
+            <label htmlFor="afternoon_evening">{shiftChoiceDetails[ShiftChoice.AFTERNOON_EVENING].label}</label>
+          </div>
+          
+          <div>
+            <input
+              type="radio"
+              id="custom"
+              name="shift"
+              value={ShiftChoice.CUSTOM}
+              checked={selectedShift === ShiftChoice.CUSTOM}
+              onChange={() => setSelectedShift(ShiftChoice.CUSTOM)}
+            />
+            <label htmlFor="custom">Aangepaste tijden</label>
+          </div>
+          {selectedShift === ShiftChoice.CUSTOM && (
+            <div className="flex items-center mt-2">
+              <div className="mr-2">Starttijd:</div>
+              <TextField type="time" id="customStartTime" value={customStartTime} onChange={(value) => setCustomStartTime(value)} />
+              <div className="mx-2">Eindtijd:</div>
+              <TextField type="time" id="customEndTime" value={customEndTime} onChange={(value) => setCustomEndTime(value)} />
+            </div>
+          )}
         </div>
 
-        {selectedShift && selectedShift !== ShiftChoice.CUSTOM && (
-          <div className="mb-4 mt-10">
-            <h2 className="font-bold">Selecteer de benodigde personeelsbezetting per shifttype:</h2>
+        {
+          <div className="mb-4 m-5 mt-10">
+            <h2 className="font-bold">Selecteer de bezetting per shift type:</h2>
             {shiftTypeNames.map((shiftTypeName) => (
               <div key={shiftTypeName} className="flex items-center mb-2">
-                <label htmlFor={shiftTypeName} className="mr-2">
-                  {shiftTypeName}
-                </label>
+                <label htmlFor={shiftTypeName} className="mr-2">{shiftTypeName}</label>
                 <div className="flex items-center">
                   <button
                     type="button"
@@ -169,6 +215,7 @@ export default function AddShiftPage() {
                     type="number"
                     id={shiftTypeName}
                     value={String(shiftTypeStaffing[shiftTypeName]) || ""}
+                    placeholder="0"
                     onChange={(value) => handleShiftTypeStaffingChange(shiftTypeName, value)}
                   />
                   <button
@@ -182,70 +229,13 @@ export default function AddShiftPage() {
               </div>
             ))}
           </div>
-        )}
-
-        {selectedShift === ShiftChoice.CUSTOM && (
-          <div className="mb-4 mt-10">
-            <h2 className="font-bold">Voeg aangepaste shifttijden toe:</h2>
-            <div className="flex items-center mb-2">
-              <label htmlFor="custom-start-time" className="mr-2">
-                Starttijd:
-              </label>
-              <TextField
-                type="time"
-                id="custom-start-time"
-                value={customStartTime}
-                onChange={(value) => setCustomStartTime(value)}
-              />
-            </div>
-            <div className="flex items-center">
-              <label htmlFor="custom-end-time" className="mr-2">
-                Eindtijd:
-              </label>
-              <TextField
-                type="time"
-                id="custom-end-time"
-                value={customEndTime}
-                onChange={(value) => setCustomEndTime(value)}
-              />
-            </div>
-            <h2 className="font-bold mt-10">Benodigd personeel per shifttype:</h2>
-            {shiftTypeNames.map((shiftTypeName) => (
-              <div key={shiftTypeName} className="flex items-center mb-2">
-                <label htmlFor={shiftTypeName} className="mr-2">
-                  {shiftTypeName}
-                </label>
-                <div className="flex items-center">
-                  <button
-                    type="button"
-                    onClick={() => handleStaffingDecrement(shiftTypeName)}
-                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 mr-2"
-                  >
-                    -
-                  </button>
-                  <TextField
-                    type="number"
-                    id={shiftTypeName}
-                    value={String(shiftTypeStaffing[shiftTypeName]) || ""}
-                    onChange={(value) => handleShiftTypeStaffingChange(shiftTypeName, value)}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => handleStaffingIncrement(shiftTypeName)}
-                    className="rounded-full px-3 py-1 bg-gray-200 text-gray-700 ml-2"
-                  >
-                    +
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {error && <p className="text-red-500 mb-4">{error}</p>}
-
+        }
         <Button type="submit">Shift toevoegen</Button>
       </form>
     </div>
   );
+
+
+
 }
+


### PR DESCRIPTION

## Description:
New feature to create shifts with validation for shift scheduling, and assigning amount of required staffings for each location/shift-type.

## Changes Made:

- Implemented a shift creation page (AddShiftPage) that allows users to input shift details.
- Added backend functions in (schedule/router) 
- Users can select a date and choose from predefined shift options or specify custom shift timings.
- Added validation to ensure that all required fields are filled before submitting the form.
- Implemented logic to handle the creation of shifts based on the selected options.

## Testing Done:

- Performed manual testing to ensure the shift creation functionality works as expected.
- Checked that all input fields are validated properly and error messages are displayed when necessary.
- Verified the creation of shifts with various options, including predefined and custom timings.

## HOW TO TEST
1. go to /addShift page 
2. Fill all fields in the form and submit
3. Go to generate-rooster and generate schedule in the same day you just added the new shift
4. Navigate in the schedule to the the choosen date
5. Check if the shift is there
